### PR TITLE
Add comment-based help for CapaOne functions

### DIFF
--- a/PS.Capa.CapaOne/Private/Build-CapaOneQuery.ps1
+++ b/PS.Capa.CapaOne/Private/Build-CapaOneQuery.ps1
@@ -3,6 +3,17 @@ function Build-CapaOneQuery (
     [hashtable]
     $Query
 ) {
+    <#
+    .SYNOPSIS
+    Builds a URL query string from key/value pairs.
+    .DESCRIPTION
+    Converts the provided hashtable into a URL encoded query string for API requests.
+    .PARAMETER Query
+    Hashtable of query string parameters.
+    .EXAMPLE
+    PS> Build-CapaOneQuery @{ filter = 'active'; page = 1 }
+    ?filter=active&page=1
+    #>
     $UrlQuery = @()
     $Query.GetEnumerator() | ForEach-Object {
         if(-not [String]::IsNullOrWhiteSpace($_.Value)){

--- a/PS.Capa.CapaOne/Private/CapaOneTemplateFunction.ps1
+++ b/PS.Capa.CapaOne/Private/CapaOneTemplateFunction.ps1
@@ -1,4 +1,12 @@
 function FunctionName {
+    <#
+    .SYNOPSIS
+    Template example for creating new CapaOne functions.
+    .DESCRIPTION
+    Demonstrates the structure of a function that calls the CapaOne API.
+    .EXAMPLE
+    PS> FunctionName
+    #>
     [CmdletBinding()]
     param ()
     $BaseUri = "/organizations/{{OrgId}}"

--- a/PS.Capa.CapaOne/Private/Invoke-CapaOneApi.ps1
+++ b/PS.Capa.CapaOne/Private/Invoke-CapaOneApi.ps1
@@ -1,4 +1,24 @@
 function Invoke-CapaOneApi {
+    <#
+    .SYNOPSIS
+    Sends a request to the CapaOne REST API.
+    .DESCRIPTION
+    Wraps Invoke-RestMethod with session handling and header management for the CapaOne API.
+    .PARAMETER Path
+    API path to invoke.
+    .PARAMETER Session
+    Web request session with authentication cookies.
+    .PARAMETER Domain
+    Base API domain.
+    .PARAMETER Method
+    HTTP method to use for the request.
+    .PARAMETER Payload
+    Hashtable representing the request body.
+    .PARAMETER Query
+    Hashtable of query string parameters.
+    .EXAMPLE
+    PS> Invoke-CapaOneApi -Path '/organizations/1/device'
+    #>
     [CmdletBinding()]
     param (
         [Parameter(Mandatory)]

--- a/PS.Capa.CapaOne/Private/New-CapaOneSession.ps1
+++ b/PS.Capa.CapaOne/Private/New-CapaOneSession.ps1
@@ -1,4 +1,12 @@
 function New-CapaOneSession {
+    <#
+    .SYNOPSIS
+    Creates a new authenticated CapaOne session.
+    .DESCRIPTION
+    Initializes a web request session and performs the initial login request to acquire cookies.
+    .EXAMPLE
+    PS> New-CapaOneSession
+    #>
     $session = New-Object Microsoft.PowerShell.Commands.WebRequestSession
     $session.UserAgent = "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/137.0.0.0 Safari/537.36"
     Invoke-CapaOneApi -Domain 'https://portal.capaone.com/api' -Path '/login' -Session $session | Out-Null

--- a/PS.Capa.CapaOne/Private/Set-CapaOneApiPath.ps1
+++ b/PS.Capa.CapaOne/Private/Set-CapaOneApiPath.ps1
@@ -1,4 +1,14 @@
 function Set-CapaOneApiPath {
+    <#
+    .SYNOPSIS
+    Expands template tokens in an API path.
+    .DESCRIPTION
+    Replaces placeholders such as {{OrgId}} with values from the current session context.
+    .PARAMETER Path
+    API path containing template placeholders.
+    .EXAMPLE
+    PS> Set-CapaOneApiPath -Path '/organizations/{{OrgId}}/device'
+    #>
     [CmdletBinding()]
     param (
         [Parameter(Mandatory)]

--- a/PS.Capa.CapaOne/Public/AdminOnDemand/Get-CapaOneDeviceAODLogs.ps1
+++ b/PS.Capa.CapaOne/Public/AdminOnDemand/Get-CapaOneDeviceAODLogs.ps1
@@ -1,4 +1,18 @@
 function Get-CapaOneDeviceAODLogs {
+    <#
+    .SYNOPSIS
+    Retrieves Admin On Demand logs for a device.
+    .DESCRIPTION
+    Gets AOD log entries for the specified device, optionally including installation status.
+    .PARAMETER DeviceId
+    Identifier of the device.
+    .PARAMETER IncludeNotInstalled
+    Include logs for actions that were not installed.
+    .PARAMETER IncludeInstalled
+    Include logs for actions that were installed.
+    .EXAMPLE
+    PS> Get-CapaOneDeviceAODLogs -DeviceId 123
+    #>
     [CmdletBinding()]
     param (
         [Parameter(Mandatory)]

--- a/PS.Capa.CapaOne/Public/Application/Get-CapaOneApplication.ps1
+++ b/PS.Capa.CapaOne/Public/Application/Get-CapaOneApplication.ps1
@@ -1,4 +1,12 @@
 function Get-CapaOneApplication {
+    <#
+    .SYNOPSIS
+    Retrieves applications from CapaOne.
+    .DESCRIPTION
+    Calls the application endpoint for the current organization.
+    .EXAMPLE
+    PS> Get-CapaOneApplication
+    #>
     [CmdletBinding()]
     param ()
     $BaseUri = "/organizations/{{OrgId}}"

--- a/PS.Capa.CapaOne/Public/Authentication/Connect-CapaOne.ps1
+++ b/PS.Capa.CapaOne/Public/Authentication/Connect-CapaOne.ps1
@@ -1,4 +1,14 @@
 function Connect-CapaOne {
+    <#
+    .SYNOPSIS
+    Establishes a session with the CapaOne service.
+    .DESCRIPTION
+    Authenticates to CapaOne using the supplied credentials and stores the session for future requests.
+    .PARAMETER Credential
+    User credential used for authentication.
+    .EXAMPLE
+    PS> Connect-CapaOne -Credential (Get-Credential)
+    #>
     [CmdletBinding()]
     param (
         [Parameter(Mandatory)]

--- a/PS.Capa.CapaOne/Public/CustomApps/Get-CapaOneCustomApp.ps1
+++ b/PS.Capa.CapaOne/Public/CustomApps/Get-CapaOneCustomApp.ps1
@@ -1,4 +1,14 @@
 function Get-CapaOneCustomApp {
+    <#
+    .SYNOPSIS
+    Retrieves custom applications from CapaOne.
+    .DESCRIPTION
+    Lists all custom applications or a specific app when an ID is supplied.
+    .PARAMETER Id
+    Optional application identifier.
+    .EXAMPLE
+    PS> Get-CapaOneCustomApp
+    #>
     [CmdletBinding()]
     param (
         [string]

--- a/PS.Capa.CapaOne/Public/CustomApps/Get-CapaOneCustomAppIcon.ps1
+++ b/PS.Capa.CapaOne/Public/CustomApps/Get-CapaOneCustomAppIcon.ps1
@@ -1,4 +1,14 @@
 function Get-CapaOneCustomAppIcon {
+    <#
+    .SYNOPSIS
+    Retrieves the icon for a custom application.
+    .DESCRIPTION
+    Downloads the icon image for the specified custom app ID.
+    .PARAMETER Id
+    Identifier of the custom application.
+    .EXAMPLE
+    PS> Get-CapaOneCustomAppIcon -Id 42
+    #>
     [CmdletBinding()]
     param (
         [Parameter(Mandatory)]

--- a/PS.Capa.CapaOne/Public/Device/Add-CapaOneDeviceToGroup.ps1
+++ b/PS.Capa.CapaOne/Public/Device/Add-CapaOneDeviceToGroup.ps1
@@ -1,4 +1,16 @@
 function Add-CapaOneDeviceToGroup {
+    <#
+    .SYNOPSIS
+    Adds devices to a CapaOne group.
+    .DESCRIPTION
+    Assigns one or more devices to the specified group.
+    .PARAMETER GroupId
+    Identifier of the group.
+    .PARAMETER DeviceId
+    One or more device identifiers to add.
+    .EXAMPLE
+    PS> Add-CapaOneDeviceToGroup -GroupId 10 -DeviceId 1,2
+    #>
     [CmdletBinding()]
     param (
         [Parameter(Mandatory)]

--- a/PS.Capa.CapaOne/Public/Device/Get-CapaOneDevice.ps1
+++ b/PS.Capa.CapaOne/Public/Device/Get-CapaOneDevice.ps1
@@ -1,4 +1,16 @@
 function Get-CapaOneDevice {
+    <#
+    .SYNOPSIS
+    Retrieves devices from CapaOne.
+    .DESCRIPTION
+    Gets device inventory, optionally filtering by name or type.
+    .PARAMETER Name
+    Device name used to filter results.
+    .PARAMETER Type
+    Device type to filter (Laptop, Desktop, Virtual).
+    .EXAMPLE
+    PS> Get-CapaOneDevice -Name "PC01"
+    #>
     [CmdletBinding()]
     param (
         [string]

--- a/PS.Capa.CapaOne/Public/Device/Get-CapaOneDeviceGroup.ps1
+++ b/PS.Capa.CapaOne/Public/Device/Get-CapaOneDeviceGroup.ps1
@@ -1,4 +1,14 @@
 function Get-CapaOneDeviceGroup {
+    <#
+    .SYNOPSIS
+    Retrieves groups assigned to a device.
+    .DESCRIPTION
+    Returns groups that contain the provided device object.
+    .PARAMETER Device
+    Device object received from the pipeline.
+    .EXAMPLE
+    PS> Get-CapaOneDevice | Get-CapaOneDeviceGroup
+    #>
     [CmdletBinding()]
     param (
         [Parameter(Mandatory,ValueFromPipeline)]

--- a/PS.Capa.CapaOne/Public/Device/Get-CapaOneDeviceInventory.ps1
+++ b/PS.Capa.CapaOne/Public/Device/Get-CapaOneDeviceInventory.ps1
@@ -1,4 +1,14 @@
 function Get-CapaOneDeviceInventory {
+    <#
+    .SYNOPSIS
+    Retrieves inventory details for a device.
+    .DESCRIPTION
+    Returns security, software, hardware, and driver information for the specified device ID.
+    .PARAMETER DeviceId
+    Identifier of the device.
+    .EXAMPLE
+    PS> Get-CapaOneDeviceInventory -DeviceId 123
+    #>
     [CmdletBinding()]
     param (
         [Parameter(Mandatory)]

--- a/PS.Capa.CapaOne/Public/Device/Get-CapaOneDeviceUpdate.ps1
+++ b/PS.Capa.CapaOne/Public/Device/Get-CapaOneDeviceUpdate.ps1
@@ -1,4 +1,18 @@
 function Get-CapaOneDeviceUpdate {
+    <#
+    .SYNOPSIS
+    Retrieves update status for a device.
+    .DESCRIPTION
+    Gets pending or installed updates for the specified device.
+    .PARAMETER DeviceId
+    Identifier of the device.
+    .PARAMETER IncludeNotInstalled
+    Include updates that are not installed.
+    .PARAMETER IncludeInstalled
+    Include updates that are already installed.
+    .EXAMPLE
+    PS> Get-CapaOneDeviceUpdate -DeviceId 1 -IncludeNotInstalled
+    #>
     [CmdletBinding()]
     param (
         [Parameter(Mandatory)]

--- a/PS.Capa.CapaOne/Public/Device/Remove-CapaOneDeviceFromGroup.ps1
+++ b/PS.Capa.CapaOne/Public/Device/Remove-CapaOneDeviceFromGroup.ps1
@@ -1,4 +1,16 @@
 function Remove-CapaOneDeviceFromGroup {
+    <#
+    .SYNOPSIS
+    Removes devices from a CapaOne group.
+    .DESCRIPTION
+    Unassigns one or more devices from the specified group.
+    .PARAMETER GroupId
+    Identifier of the group.
+    .PARAMETER DeviceId
+    One or more device identifiers to remove.
+    .EXAMPLE
+    PS> Remove-CapaOneDeviceFromGroup -GroupId 10 -DeviceId 1,2
+    #>
     [CmdletBinding()]
     param (
         [Parameter(Mandatory)]

--- a/PS.Capa.CapaOne/Public/Enrollment/Get-CapaOneEnrollment.ps1
+++ b/PS.Capa.CapaOne/Public/Enrollment/Get-CapaOneEnrollment.ps1
@@ -1,4 +1,14 @@
 function Get-CapaOneEnrollment {
+    <#
+    .SYNOPSIS
+    Retrieves enrollment information from CapaOne.
+    .DESCRIPTION
+    Calls the enrollment endpoint for the current organization.
+    .PARAMETER ParameterName
+    Placeholder parameter reserved for future functionality.
+    .EXAMPLE
+    PS> Get-CapaOneEnrollment
+    #>
     [CmdletBinding()]
     param (
         [Parameter()]

--- a/PS.Capa.CapaOne/Public/MDM/Android/Get-CapaOneMDMAndroidEndpoint.ps1
+++ b/PS.Capa.CapaOne/Public/MDM/Android/Get-CapaOneMDMAndroidEndpoint.ps1
@@ -1,4 +1,14 @@
 function Get-CapaOneMDMAndroidEndpoint {
+    <#
+    .SYNOPSIS
+    Retrieves Android MDM endpoints.
+    .DESCRIPTION
+    Calls the Android enterprise endpoint for the current organization.
+    .PARAMETER ParameterName
+    Placeholder parameter reserved for future functionality.
+    .EXAMPLE
+    PS> Get-CapaOneMDMAndroidEndpoint
+    #>
     [CmdletBinding()]
     param (
         [Parameter()]

--- a/PS.Capa.CapaOne/Public/MDM/Apple/Get-CapaOneMDMAppleApplication.ps1
+++ b/PS.Capa.CapaOne/Public/MDM/Apple/Get-CapaOneMDMAppleApplication.ps1
@@ -1,4 +1,12 @@
 function Get-CapaOneMDMAppleApplication {
+    <#
+    .SYNOPSIS
+    Retrieves Apple MDM applications.
+    .DESCRIPTION
+    Calls the Apple application endpoint for the current organization.
+    .EXAMPLE
+    PS> Get-CapaOneMDMAppleApplication
+    #>
     [CmdletBinding()]
     param ()
     $BaseUri = "/organizations/{{OrgId}}/apple"

--- a/PS.Capa.CapaOne/Public/MDM/Apple/Get-CapaOneMDMAppleCertificate.ps1
+++ b/PS.Capa.CapaOne/Public/MDM/Apple/Get-CapaOneMDMAppleCertificate.ps1
@@ -1,4 +1,12 @@
 function Get-CapaOneMDMAppleCertificate {
+    <#
+    .SYNOPSIS
+    Retrieves Apple MDM certificates.
+    .DESCRIPTION
+    Calls the Apple cluster endpoint to obtain certificate information.
+    .EXAMPLE
+    PS> Get-CapaOneMDMAppleCertificate
+    #>
     [CmdletBinding()]
     param ()
     $BaseUri = "/organizations/{{OrgId}}/apple"

--- a/PS.Capa.CapaOne/Public/MDM/Apple/Get-CapaOneMDMAppleConfiguration.ps1
+++ b/PS.Capa.CapaOne/Public/MDM/Apple/Get-CapaOneMDMAppleConfiguration.ps1
@@ -1,4 +1,12 @@
 function Get-CapaOneMDMAppleConfiguration {
+    <#
+    .SYNOPSIS
+    Retrieves Apple MDM configuration.
+    .DESCRIPTION
+    Calls the Apple configuration endpoint for the organization.
+    .EXAMPLE
+    PS> Get-CapaOneMDMAppleConfiguration
+    #>
     [CmdletBinding()]
     param ()
     $BaseUri = "/organizations/{{OrgId}}/apple"

--- a/PS.Capa.CapaOne/Public/MDM/Apple/Get-CapaOneMDMAppleEndpoint.ps1
+++ b/PS.Capa.CapaOne/Public/MDM/Apple/Get-CapaOneMDMAppleEndpoint.ps1
@@ -1,4 +1,14 @@
 function Get-CapaOneMDMAppleEndpoint {
+    <#
+    .SYNOPSIS
+    Retrieves Apple MDM endpoints.
+    .DESCRIPTION
+    Queries Apple endpoints filtered by device type.
+    .PARAMETER Type
+    Device type to filter (Mobile or Mac).
+    .EXAMPLE
+    PS> Get-CapaOneMDMAppleEndpoint -Type Mobile
+    #>
     [CmdletBinding()]
     param (
         [Parameter()]

--- a/PS.Capa.CapaOne/Public/MDM/Apple/Get-CapaOneMDMAppleEnrollmentConfiguration.ps1
+++ b/PS.Capa.CapaOne/Public/MDM/Apple/Get-CapaOneMDMAppleEnrollmentConfiguration.ps1
@@ -1,4 +1,14 @@
 function Get-CapaOneMDMAppleEnrollmentConfiguration {
+    <#
+    .SYNOPSIS
+    Retrieves Apple enrollment configuration.
+    .DESCRIPTION
+    Calls the Apple enrollment configuration endpoint for the organization.
+    .PARAMETER ParameterName
+    Placeholder parameter reserved for future use.
+    .EXAMPLE
+    PS> Get-CapaOneMDMAppleEnrollmentConfiguration
+    #>
     [CmdletBinding()]
     param (
         [Parameter()]

--- a/PS.Capa.CapaOne/Public/MDM/Apple/Get-CapaOneMDMAppleVPP.ps1
+++ b/PS.Capa.CapaOne/Public/MDM/Apple/Get-CapaOneMDMAppleVPP.ps1
@@ -1,4 +1,12 @@
 function Get-CapaOneMDMAppleVPP {
+    <#
+    .SYNOPSIS
+    Retrieves Apple VPP information.
+    .DESCRIPTION
+    Calls the Apple Volume Purchase Program endpoint for the current organization.
+    .EXAMPLE
+    PS> Get-CapaOneMDMAppleVPP
+    #>
     [CmdletBinding()]
     param ()
     $BaseUri = "/organizations/{{OrgId}}/apple"

--- a/PS.Capa.CapaOne/Public/MDM/Get-CapaOneMDM.ps1
+++ b/PS.Capa.CapaOne/Public/MDM/Get-CapaOneMDM.ps1
@@ -1,4 +1,14 @@
 function Get-CapaOneMDM {
+    <#
+    .SYNOPSIS
+    Retrieves MDM configuration for the organization.
+    .DESCRIPTION
+    Returns Apple and Android MDM configuration details.
+    .PARAMETER ParameterName
+    Placeholder parameter reserved for future use.
+    .EXAMPLE
+    PS> Get-CapaOneMDM
+    #>
     [CmdletBinding()]
     param (
         [Parameter()]

--- a/PS.Capa.CapaOne/Public/Management/Group/Get-CapaOneGroup.ps1
+++ b/PS.Capa.CapaOne/Public/Management/Group/Get-CapaOneGroup.ps1
@@ -1,4 +1,18 @@
 function Get-CapaOneGroup {
+    <#
+    .SYNOPSIS
+    Retrieves groups from CapaOne.
+    .DESCRIPTION
+    Queries group information, optionally filtering by name or ID and including device assignments.
+    .PARAMETER Name
+    Filter groups by name.
+    .PARAMETER GroupId
+    Filter by a specific group ID.
+    .PARAMETER WithDevices
+    Include device assignments in the result.
+    .EXAMPLE
+    PS> Get-CapaOneGroup -WithDevices
+    #>
     [CmdletBinding()]
     param (
         [string]

--- a/PS.Capa.CapaOne/Public/Management/Group/New-CapaOneGroup.ps1
+++ b/PS.Capa.CapaOne/Public/Management/Group/New-CapaOneGroup.ps1
@@ -1,4 +1,16 @@
 function New-CapaOneGroup {
+    <#
+    .SYNOPSIS
+    Creates a new CapaOne group.
+    .DESCRIPTION
+    Adds a group with the specified name and optional description.
+    .PARAMETER Name
+    Name of the new group.
+    .PARAMETER Description
+    Optional description for the group.
+    .EXAMPLE
+    PS> New-CapaOneGroup -Name "HR"
+    #>
     [CmdletBinding()]
     param (
         [ValidateNotNullOrWhiteSpace()]

--- a/PS.Capa.CapaOne/Public/Management/Group/Remove-CapaOneGroup.ps1
+++ b/PS.Capa.CapaOne/Public/Management/Group/Remove-CapaOneGroup.ps1
@@ -1,4 +1,14 @@
 function Remove-CapaOneGroup {
+    <#
+    .SYNOPSIS
+    Removes a CapaOne group.
+    .DESCRIPTION
+    Deletes a group by its identifier with confirmation support.
+    .PARAMETER GroupId
+    Identifier of the group to remove.
+    .EXAMPLE
+    PS> Remove-CapaOneGroup -GroupId 1 -Confirm:$false
+    #>
     [CmdletBinding(
         SupportsShouldProcess = $true,   # ⇒ adds –Confirm / –WhatIf
         ConfirmImpact = 'High' # default; use High for risky ops

--- a/PS.Capa.CapaOne/Public/Management/Group/Update-CapaOneGroup.ps1
+++ b/PS.Capa.CapaOne/Public/Management/Group/Update-CapaOneGroup.ps1
@@ -1,4 +1,18 @@
 function Update-CapaOneGroup {
+    <#
+    .SYNOPSIS
+    Updates a CapaOne group.
+    .DESCRIPTION
+    Modifies the name or description of an existing group.
+    .PARAMETER GroupId
+    Identifier of the group to update.
+    .PARAMETER Name
+    New name for the group.
+    .PARAMETER Description
+    Optional description for the group.
+    .EXAMPLE
+    PS> Update-CapaOneGroup -GroupId 1 -Name 'NewName'
+    #>
     [CmdletBinding()]
     param (
         [Parameter(Mandatory)]

--- a/PS.Capa.CapaOne/Public/Management/Integration/Get-CapaOneIntegration.ps1
+++ b/PS.Capa.CapaOne/Public/Management/Integration/Get-CapaOneIntegration.ps1
@@ -1,4 +1,12 @@
 function Get-CapaOneIntegration {
+    <#
+    .SYNOPSIS
+    Retrieves integration information.
+    .DESCRIPTION
+    Calls the integration endpoint for the current organization.
+    .EXAMPLE
+    PS> Get-CapaOneIntegration
+    #>
     [CmdletBinding()]
     param ()
     $BaseUri = "/organizations/{{OrgId}}"

--- a/PS.Capa.CapaOne/Public/Management/Integration/Sync-CapaOneIntegration.ps1
+++ b/PS.Capa.CapaOne/Public/Management/Integration/Sync-CapaOneIntegration.ps1
@@ -1,4 +1,14 @@
 function Sync-CapaOneIntegration {
+    <#
+    .SYNOPSIS
+    Triggers synchronization for a CapaOne integration.
+    .DESCRIPTION
+    Initiates a sync for the specified integration ID and returns success status.
+    .PARAMETER IntegrationId
+    Identifier of the integration to sync.
+    .EXAMPLE
+    PS> Sync-CapaOneIntegration -IntegrationId 5
+    #>
     [CmdletBinding()]
     param (
         [Parameter()]

--- a/PS.Capa.CapaOne/Public/Management/Reporting/Get-CapaOneReport.ps1
+++ b/PS.Capa.CapaOne/Public/Management/Reporting/Get-CapaOneReport.ps1
@@ -1,4 +1,14 @@
 function Get-CapaOneReport {
+    <#
+    .SYNOPSIS
+    Retrieves a report from CapaOne.
+    .DESCRIPTION
+    Downloads report items based on the specified template.
+    .PARAMETER Template
+    Report template identifier.
+    .EXAMPLE
+    PS> Get-CapaOneReport -Template 'deviceStatus'
+    #>
     [CmdletBinding()]
     param (
         [Parameter(Mandatory)]

--- a/PS.Capa.CapaOne/Public/Management/User/Get-CapaOneUser.ps1
+++ b/PS.Capa.CapaOne/Public/Management/User/Get-CapaOneUser.ps1
@@ -1,4 +1,14 @@
 function Get-CapaOneUser {
+    <#
+    .SYNOPSIS
+    Retrieves users from CapaOne.
+    .DESCRIPTION
+    Queries the user management endpoint optionally filtering by name.
+    .PARAMETER Name
+    Name or pattern used to filter results.
+    .EXAMPLE
+    PS> Get-CapaOneUser -Name 'John'
+    #>
     [CmdletBinding()]
     param (
         [Parameter()]

--- a/PS.Capa.CapaOne/Public/Organization/Get-CapaOneContracts.ps1
+++ b/PS.Capa.CapaOne/Public/Organization/Get-CapaOneContracts.ps1
@@ -1,4 +1,12 @@
 function Get-CapaOneContracts {
+    <#
+    .SYNOPSIS
+    Returns contract information for the current organization.
+    .DESCRIPTION
+    Retrieves contract data stored during a successful CapaOne connection.
+    .EXAMPLE
+    PS> Get-CapaOneContracts
+    #>
     if($null -ne $Script:CapaOneStructure){
         return $Script:CapaOneStructure.contracts
     }else{

--- a/PS.Capa.CapaOne/Public/Tags/Get-CapaOneTag.ps1
+++ b/PS.Capa.CapaOne/Public/Tags/Get-CapaOneTag.ps1
@@ -1,4 +1,12 @@
 function Get-CapaOneTag {
+    <#
+    .SYNOPSIS
+    Retrieves tags defined in CapaOne.
+    .DESCRIPTION
+    Calls the tag endpoint for the current organization.
+    .EXAMPLE
+    PS> Get-CapaOneTag
+    #>
     [CmdletBinding()]
     param ()
     $BaseUri = "/organizations/{{OrgId}}"

--- a/PS.Capa.CapaOne/Public/Temp/Get-CapaOneConnectionResponse.ps1
+++ b/PS.Capa.CapaOne/Public/Temp/Get-CapaOneConnectionResponse.ps1
@@ -1,3 +1,11 @@
 function Get-CapaOneConnectionResponse {
+    <#
+    .SYNOPSIS
+    Gets the last connection response from CapaOne.
+    .DESCRIPTION
+    Returns the structure object received during authentication.
+    .EXAMPLE
+    PS> Get-CapaOneConnectionResponse
+    #>
     return $Script:CapaOneStructure
 }

--- a/PS.Capa.CapaOne/Public/Temp/Get-CapaOneSessionVariable.ps1
+++ b/PS.Capa.CapaOne/Public/Temp/Get-CapaOneSessionVariable.ps1
@@ -1,3 +1,11 @@
 function Get-CapaOneSessionVariable {
+    <#
+    .SYNOPSIS
+    Retrieves the current CapaOne session object.
+    .DESCRIPTION
+    Returns the web request session used for subsequent API calls.
+    .EXAMPLE
+    PS> Get-CapaOneSessionVariable
+    #>
     return $Script:CapaOneSession
 }

--- a/PS.Capa.CapaOne/Public/User/Get-CapaOneUserProfile.ps1
+++ b/PS.Capa.CapaOne/Public/User/Get-CapaOneUserProfile.ps1
@@ -1,4 +1,12 @@
 function Get-CapaOneUserProfile {
+    <#
+    .SYNOPSIS
+    Retrieves the current user's profile information.
+    .DESCRIPTION
+    Requests the user profile for the connected organization.
+    .EXAMPLE
+    PS> Get-CapaOneUserProfile
+    #>
     [CmdletBinding()]
     param ()
     $BaseUri = "/organizations/{{OrgId}}"


### PR DESCRIPTION
## Summary
- document CapaOne module private and public functions with comment-based PowerShell help

## Testing
- `pwsh -NoLogo -NoProfile -Command "Import-Module ./PS.Capa.CapaOne.psd1"` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a868b7074083258a9c8a3d8e68c500